### PR TITLE
Sequoia Checker fixes

### DIFF
--- a/MacOS Sequoia STIG Tools/MacOS 15 Sequoia Beta STIG CHECKER.sh
+++ b/MacOS Sequoia STIG Tools/MacOS 15 Sequoia Beta STIG CHECKER.sh
@@ -14,7 +14,8 @@
 #   History
 #
 #  1.0 8/21/24 - Based off (MacOS Sonoma STIG Tools/MacOS 14 Sonoma V2R1 STIG CHECKER.sh)
-#
+#  1.1 8/27/24 - Corrected initialize_logging to write CSV header correctly
+#                Fixed check for V-259427 the \ was causing the check to fail
 ####################################################################################################
 # Script Supported STIG Version
 STIG_VERSION="MACOS 15 (SEQUOIA) BETA" # [ Do Not Adjust ]
@@ -502,18 +503,18 @@ initialize_logging() {
     if [ "$LOG_TO_CSV" = true ]; then
         if [ ! -f "$CSV_LOG_FILE" ]; then
             # File does not exist; write the header
-            echo "$HEADER" >"$CSV_LOG_FILE"
+            echo "$csv_header" >"$CSV_LOG_FILE"
 
             if [ "$LOG_RESULTS_TO_USER_LOG_FOLDER" = true ]; then
-                echo "$HEADER" >"$USER_CSV_LOG_FILE"
+                echo "$csv_header" >"$USER_CSV_LOG_FILE"
             fi
 
-        elif ! grep -q "^$HEADER$" "$CSV_LOG_FILE"; then
+        elif ! grep -q "^$csv_header$" "$CSV_LOG_FILE"; then
             # File exists but does not contain the header; add the header
-            echo "$HEADER" >>"$CSV_LOG_FILE"
+            echo "$csv_header" >>"$CSV_LOG_FILE"
 
             if [ "$LOG_RESULTS_TO_USER_LOG_FOLDER" = true ]; then
-                echo "$HEADER" >>"$USER_CSV_LOG_FILE"
+                echo "$csv_header" >>"$USER_CSV_LOG_FILE"
             fi
         fi
     fi
@@ -871,7 +872,7 @@ execute_and_log "$check_name" "$command" "$expected_result" "$simple_name"
 ##############################################
 check_name="V-259427"
 simple_name="Must_Be_Intergrated_Into_A_Directory_Services_Infrastructure"
-command="/usr/bin/dscl localhost -list . \| /usr/bin/grep -qvE '(Contact\|Search\|Local\|^$)'; /bin/echo $?"
+command="/usr/bin/dscl localhost -list . | /usr/bin/grep -qvE '(Contact|Search|Local|^$)'; /bin/echo $?"
 expected_result="0"
 
 execute_and_log "$check_name" "$command" "$expected_result" "$simple_name"


### PR DESCRIPTION
Fixed the following issues:
- The initialize_logging function was not writting the header to the file due to an undeclared variable.
- Check V-259427 was not properly filtering with the grep due to having a `\` in the expresion along with one before the pipe and no space