### PR TITLE
Update MacOS_26_Tahoe_V1R1_STIG_Compliance_Tool.sh

### DIFF
--- a/MacOS_Tahoe_STIG_Tools/MacOS_26_Tahoe_V1R1_STIG_Compliance_Tool.sh
+++ b/MacOS_Tahoe_STIG_Tools/MacOS_26_Tahoe_V1R1_STIG_Compliance_Tool.sh
@@ -1700,7 +1700,7 @@ execute_and_log "$check_name" "$check_command" "$expected_result" "$simple_name"
 ##############################################
 check_name="APPL-26-000190"
 simple_name="os_sudo_log_enforce"
-check_command="/usr/bin/sudo /usr/bin/sudo -V | /usr/bin/grep -c "Log when a command is allowed by sudoers""
+check_command="/usr/bin/sudo -V | /usr/bin/grep -c \"Log when a command is allowed by sudoers"\"
 expected_result="1"
 severity="CAT II"
 fix_command="/usr/bin/find /etc/sudoers* -type f -exec sed -i '' '/^Defaults[[:blank:]]*\!log_allowed/s/^/# /' '{}' \;


### PR DESCRIPTION
- APPL-26-000057- Updated the scanning command to include security key algorithms (sk-ecdsg variants) in HostKeyAlgorithms, PubkeyAcceptedAlgorithms, and CASignatureAlgorithms, plus hmac-sha2-256-etm@openssh.com in MACs list.
- APPL-26-000190 - Fixed command as to not sudo a sudo. 
- APPL-26-002037 - Added a capital “S” to SkipSetupItems.
- APPL-26-003010 - Confirmed command looks for pass/fail. DISA STIG looks for true/false.